### PR TITLE
Update README-Windows.md

### DIFF
--- a/README-Windows.md
+++ b/README-Windows.md
@@ -6,16 +6,16 @@ This smart contract saves and records the status messages of NEAR accounts that 
 **Note**: this README is specific to Windows and this example. For development on OS X or Linux, please see [README.md](README.md).
 
 ## Prerequisite
-Ensure `near-shell` is installed by running:
+Ensure `near-cli` is installed by running:
 
 ```
 near --version
 ```
 
-If needed, install `near-shell`:
+If needed, install `near-cli`:
 
 ```
-npm install near-shell -g
+npm install near-cli -g
 ```
 
 ## Building this contract
@@ -83,7 +83,7 @@ In this second option, the smart contract will get deployed to a specific accoun
 
 If you do not have a NEAR account, please create one with [NEAR Wallet](https://wallet.nearprotocol.com).
 
-In the project root, login with `near-shell` by following the instructions after this command:
+In the project root, login with `near-cli` by following the instructions after this command:
 
 ```
 near login


### PR DESCRIPTION
`near-shell` package has been renamed to `near-cli`.