### PR TITLE
Change workflow trigger action for "push" to "pull_request"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Tests
-on: push
+on: pull_request
 jobs:
   tests:
     strategy:


### PR DESCRIPTION
Hello. I noticed that you have a workflow to run tests on different OSes which is very useful. But it doesn't run, because it is set to be run on every push, so it's easy to lose the point where tests become broken, moreover since contributors work in their own forks it's even more unclear. The proposal is very simple, to run tests on every change in a PR.